### PR TITLE
Update Travis config to build on older rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,4 @@ rvm:
   - 2.3
   - 2.4
   - 2.5
-before_install:
-  - gem update --system
-  - gem install bundler
-sudo: false
 cache: bundler
-

--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,8 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
-  if RUBY_VERSION < '1.9.3'
-    gem 'rake', '< 11'
-  else
-    gem 'rake'
-    gem 'test-unit'
-  end
+  gem 'rake'
+  gem 'test-unit'
 
   if RUBY_VERSION < '2.2.2'
     gem 'rack-test', '~> 0.7.0'

--- a/bundler.d/dhcp_remote_isc.rb
+++ b/bundler.d/dhcp_remote_isc.rb
@@ -1,4 +1,4 @@
 group :dhcp_remote_isc do
-  gem 'rsec'
+  gem 'rsec', '< 1'
 end
 gem 'smart_proxy_dhcp_remote_isc'

--- a/smart_proxy_dhcp_remote_isc.gemspec
+++ b/smart_proxy_dhcp_remote_isc.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |s|
   s.files       = Dir['{config,lib,bundler.d}/**/*'] + ['README.md', 'LICENSE']
   s.test_files  = Dir['test/**/*']
 
-  s.add_development_dependency 'rsec'
+  s.add_development_dependency 'rsec', '< 1'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,5 @@
 require 'test/unit'
-require 'mocha/setup'
+require 'mocha/test_unit'
 
 require 'smart_proxy_for_testing'
 


### PR DESCRIPTION
The latest bundler doesn't work on older rubies and the default versions should be good enough. The sudo: false is also deprecated and ignored by Travis so it can be dropped.